### PR TITLE
SLING-7788 Create Spec conform ServiceRegistration from DS Metadata

### DIFF
--- a/src/main/java/org/apache/sling/testing/mock/osgi/MockServiceRegistration.java
+++ b/src/main/java/org/apache/sling/testing/mock/osgi/MockServiceRegistration.java
@@ -61,14 +61,14 @@ class MockServiceRegistration<T> implements ServiceRegistration<T>, Comparable<M
         else {
             this.service = service;
         }
-        
+
+        readOsgiMetadata();
+
         this.properties = properties != null ? properties : new Hashtable<String,Object>();
         this.properties.put(Constants.SERVICE_ID, this.serviceId);
-        this.properties.put(Constants.OBJECTCLASS, clazzes);
+        this.properties.put(Constants.OBJECTCLASS, this.clazzes.toArray(new String[0]));
         this.serviceReference = new MockServiceReference<T>(bundle, this);
         this.bundleContext = bundleContext;
-        
-        readOsgiMetadata();
     }
 
     @Override

--- a/src/test/java/org/apache/sling/testing/mock/osgi/context/OsgiContextImplTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/osgi/context/OsgiContextImplTest.java
@@ -166,7 +166,6 @@ public class OsgiContextImplTest {
     }
 
     @Test
-    @Ignore("SLING-7788")
     public void testServiceTracker() {
         BundleContext bundleContext = context.bundleContext();
         ServiceTracker<MyService, MyService> tracker = new ServiceTracker<>(bundleContext, MyService.class, null);

--- a/src/test/java/org/apache/sling/testing/mock/osgi/context/OsgiContextImplTest.java
+++ b/src/test/java/org/apache/sling/testing/mock/osgi/context/OsgiContextImplTest.java
@@ -34,8 +34,12 @@ import org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest.ServiceInterface1;
 import org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest.ServiceInterface2;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.util.tracker.ServiceTracker;
 
 public class OsgiContextImplTest {
 
@@ -161,4 +165,35 @@ public class OsgiContextImplTest {
         context.registerInjectActivateService(new Object());
     }
 
+    @Test
+    @Ignore("SLING-7788")
+    public void testServiceTracker() {
+        BundleContext bundleContext = context.bundleContext();
+        ServiceTracker<MyService, MyService> tracker = new ServiceTracker<>(bundleContext, MyService.class, null);
+        tracker.open();
+
+        context.registerInjectActivateService(new MyComponent());
+
+        assertNotNull(tracker.getServiceReferences());
+        assertEquals(1, tracker.getServiceReferences().length);
+
+        tracker.close();
+    }
+
+    @Component(
+            service = MyService.class
+    )
+    public static class MyComponent implements MyService {
+
+        @Override
+        public String foo() {
+            return "bar";
+        }
+    }
+
+    public interface MyService {
+
+        String foo();
+
+    }
 }

--- a/src/test/resources/OSGI-INF/org.apache.sling.testing.mock.osgi.context.OsgiContextImplTest.xml
+++ b/src/test/resources/OSGI-INF/org.apache.sling.testing.mock.osgi.context.OsgiContextImplTest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<components xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0">
+    <scr:component name="org.apache.sling.testing.mock.osgi.context.OsgiContextImplTest$MyComponent">
+        <implementation class="org.apache.sling.testing.mock.osgi.context.OsgiContextImplTest$MyComponent"/>
+        <service>
+            <provide interface="org.apache.sling.testing.mock.osgi.context.OsgiContextImplTest$MyService"/>
+        </service>
+    </scr:component>
+</components>


### PR DESCRIPTION
So far the OSGI Metadata for DS components were read and added to the metadata used by the ServiceRegistration to implement its interface. Unfortunately the service implemented from the DS Metadata merged with the ones passed to the constructor were not properly exposed as service property and so made the ServiceRegistration incompatible to ServiceTracker (for example). This has been resolved by changing the order of execution in the constructor and verified with a test. 