### PR TITLE
Add test case to show volatile list reference having incorrect order

### DIFF
--- a/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtil.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtil.java
@@ -22,15 +22,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.impl.inject.Annotations;
@@ -443,7 +435,11 @@ final class OsgiServiceUtil {
         // multiple references found? inject only first one with highest ranking
         if (matchingServices.size() > 1 && !reference.isCardinalityMultiple()) {
             matchingServices = matchingServices.subList(0, 1);
+        } else {
+            // sorting based on lowest ranking first
+            matchingServices.sort(Comparator.comparing(ServiceInfo::getServiceReference));
         }
+
 
         // try to invoke bind method
         for (ServiceInfo matchingService : matchingServices) {

--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilTest.java
@@ -624,5 +624,64 @@ public class OsgiServiceUtilTest {
     public static class ServiceFactory1 {
         
     }
-        
+
+    public interface RankedService {
+        int getRanking();
+    }
+
+    @Component(
+            properties = {
+                    "service.ranking:Integer=5"
+            }
+    )
+    public static class RankedServiceFive implements RankedService {
+
+        private int ranking;
+
+        @Activate
+        public void activate(Map<String, Object> properties) {
+            this.ranking = (Integer) properties.get("service.ranking");
+        }
+
+        @Override
+        public int getRanking() {
+            return ranking;
+        }
+    }
+
+    @Component(
+            properties = {
+                    "service.ranking:Integer=10"
+            }
+    )
+    public static class RankedServiceTen implements RankedService {
+
+        private int ranking;
+
+        @Activate
+        public void activate(Map<String, Object> properties) {
+            this.ranking = (Integer) properties.get("service.ranking");
+        }
+
+        @Override
+        public int getRanking() {
+            return ranking;
+        }
+    }
+
+    @Component(service = Service6VolatileMultipleReferences.class)
+    public static class Service6VolatileMultipleReferences {
+
+        @Reference
+        private volatile List<RankedService> rankedServices;
+
+        public String getRanks() {
+            StringBuilder builder = new StringBuilder();
+            for(RankedService rankedService : rankedServices) {
+                builder.append(rankedService.getClass().getSimpleName()).append("=").append(rankedService.getRanking());
+            }
+            return builder.toString();
+        }
+    }
+
 }

--- a/core/src/test/resources/OSGI-INF/org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest.xml
+++ b/core/src/test/resources/OSGI-INF/org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest.xml
@@ -83,4 +83,25 @@
     </service>
     <property name="service.pid" value="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$ServiceFactory1"/>
   </scr:component>
+  <scr:component name="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedServiceFive" activate="activate">
+    <property name="service.ranking" type="Integer" value="5"/>
+    <service>
+      <provide interface="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedService"/>
+    </service>
+    <implementation class="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedServiceFive"/>
+  </scr:component>
+  <scr:component name="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedServiceTen" activate="activate">
+    <property name="service.ranking" type="Integer" value="10"/>
+    <service>
+      <provide interface="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedService"/>
+    </service>
+    <implementation class="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedServiceTen"/>
+  </scr:component>
+  <scr:component name="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$Service6VolatileMultipleReferences">
+    <service>
+      <provide interface="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$Service6VolatileMultipleReferences"/>
+    </service>
+    <reference name="rankedServices" cardinality="0..n" policy="dynamic" interface="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$RankedService" field="rankedServices" field-collection-type="service"/>
+    <implementation class="org.apache.sling.testing.mock.osgi.OsgiServiceUtilTest$Service6VolatileMultipleReferences"/>
+  </scr:component>
 </components>


### PR DESCRIPTION
This PR will fail, but it should succeed 