### PR TITLE
SLING-11860 OsgiServiceUtil may invoke the wrong method

### DIFF
--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilActivateDeactivateTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilActivateDeactivateTest.java
@@ -41,6 +41,7 @@ import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeacti
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.Service6Constructor;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.Service7;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.Service7Constructor;
+import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.Service9;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.ServiceReferenceInConstructor;
 import org.junit.Assert;
 import org.junit.Test;
@@ -242,4 +243,17 @@ public class OsgiServiceUtilActivateDeactivateTest {
             assertTrue("Expected exception message matching regex:\n" + regex + "\nbut got:\n" + e.getMessage(), e.getMessage().matches(regex));
         }
     }
+
+    /**
+     * SLING-11860 verify OsgiServiceUtil#activateDeactivate invokes the correct activate and deactivate methods
+     */
+    @Test 
+    public void testService9ActivateDeactivate() {
+        Service9 service = MockOsgi.activateInjectServices(Service9.class, bundleContext, map);
+        assertEquals(Service9.class, service.getActivateFromClass());
+
+        MockOsgi.deactivate(service, bundleContext, map);
+        assertEquals(Service9.class, service.getDeactivateFromClass());
+    }
+
 }

--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilBindUnbindTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilBindUnbindTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.ServiceInterface1;
+import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate.Service9;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.bindunbind.Service1;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.bindunbind.Service2;
 import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.bindunbind.Service3;
@@ -164,6 +165,19 @@ public class OsgiServiceUtilBindUnbindTest {
                 .map(actualItem -> Maps.filterEntries(actualItem, item -> item.getKey().equals("prop1")))
                 .collect(Collectors.toList());
         assertItems(actualFiltered, expected);
+    }
+
+
+    /**
+     * SLING-11860 verify OsgiServiceUtil#invokeBindUnbindMethod invokes the correct bind and unbind methods
+     */
+    @Test 
+    public void testService9BindUnbind() {
+        Service9 service9 = registerInjectService(new Service9());
+        assertEquals(Service9.class, service9.getBindSvc1FromClass());
+
+        reg1a.unregister();
+        assertEquals(Service9.class, service9.getUnbindSvc1FromClass());
     }
 
 }

--- a/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/activatedeactivate/Service9.java
+++ b/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/activatedeactivate/Service9.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate;
+
+import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.ServiceInterface1;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * SLING-11860 - subclass to provide more specific activate/deactivate methods
+ */
+@Component(service = ServiceInterface1.class)
+public class Service9 extends Service9Super1 {
+
+    @Activate
+    protected void activate(ServiceConfig config) {
+        activateFromClass = Service9.class;
+    }
+
+    @Deactivate
+    protected void deactivate(ServiceConfig config) {
+        deactivateFromClass = Service9.class;
+    }
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL)
+    protected void bindServiceInterface1(ServiceInterface1 svc1, ServiceReference<ServiceInterface1> svc1Ref) {
+        bindSvc1FromClass = Service9.class;
+    }
+
+    protected void unbindServiceInterface1(ServiceInterface1 svc1, ServiceReference<ServiceInterface1> svc1Ref) {
+        unbindSvc1FromClass = Service9.class;
+    }
+
+}

--- a/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/activatedeactivate/Service9Super1.java
+++ b/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/activatedeactivate/Service9Super1.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.activatedeactivate;
+
+import java.util.Map;
+
+import org.apache.sling.testing.mock.osgi.testsvc.osgiserviceutil.ServiceInterface1;
+
+/**
+ * SLING-11860 - Superclass that provides generic activate/deactivate methods
+ */
+public abstract class Service9Super1 implements ServiceInterface1 {
+
+    protected Class<?> activateFromClass = null;
+    protected Class<?> deactivateFromClass = null;
+    protected Class<?> bindSvc1FromClass = null;
+    protected Class<?> unbindSvc1FromClass = null;
+
+    protected void activate(Map<String, Object> props) {
+        activateFromClass = Service9Super1.class;
+    }
+
+    protected void deactivate(Map<String, Object> props) {
+        deactivateFromClass = Service9Super1.class;
+    }
+
+    protected void bindServiceInterface2(ServiceInterface1 svc1) {
+        bindSvc1FromClass = Service9Super1.class;
+    }
+
+    protected void unbindServiceInterface2(ServiceInterface1 svc1) {
+        unbindSvc1FromClass = Service9Super1.class;
+    }
+
+    public Class<?> getActivateFromClass() {
+        return activateFromClass;
+    }
+
+    public Class<?> getDeactivateFromClass() {
+        return deactivateFromClass;
+    }
+
+    public Class<?> getBindSvc1FromClass() {
+        return bindSvc1FromClass;
+    }
+
+    public Class<?> getUnbindSvc1FromClass() {
+        return unbindSvc1FromClass;
+    }
+
+}


### PR DESCRIPTION
Impacts both the activate/deactivate methods and the bind/unbind methods.

The scenario where this happens is when the parent class has an activate/deactivate/bind/unbind method with one set of arguments and the subclass has an activate/deactivate/bind/unbind method with the same name but with a different set of arguments.

For example, when the context.registerInjectActivateService(..) call is invoked,  it finds the activate(Map) method from the parent class and invokes it and then returns instead of calling the more specific activate(Config) methods from the subclass.


The fix proposed here is to change the method matching algorithm to be a "nearest match" approach where it checks all the possibilities on the current candidate class before walking up the superclasses to find a match.
