### PR TITLE
SLING-11916 - MockEventAdminTest.testPostEvents times out on Jenkins/Windows

### DIFF
--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/MockEventAdminTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/MockEventAdminTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.testing.mock.osgi;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Dictionary;
 import java.util.List;
@@ -107,7 +108,7 @@ public class MockEventAdminTest {
         eventAdmin.postEvent(EVENT_SAMPLE_2);
         eventAdmin.postEvent(EVENT_OTHER_3);
 
-        // wait until result is as expected (with timeout)
+        // wait until result is as expected (with timeout) - events are distributed in async manner
         boolean expectedResult = false;
         while (!expectedResult) {
             expectedResult = Objects.equals(ImmutableList.of(), eventHandler1.getReceivedEvents())
@@ -115,6 +116,7 @@ public class MockEventAdminTest {
                     && Objects.equals(ImmutableList.of(EVENT_SAMPLE_2), eventHandlerSampleAll.getReceivedEvents())
                     && Objects.equals(ImmutableList.of(EVENT_SAMPLE_2, EVENT_OTHER_3), eventHandlerAll.getReceivedEvents());
         }
+        assertTrue(expectedResult);
     }
 
     private static class DummyEventHandler implements EventHandler {

--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/MockEventAdminTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/MockEventAdminTest.java
@@ -20,10 +20,10 @@ package org.apache.sling.testing.mock.osgi;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.Before;
@@ -119,7 +119,7 @@ public class MockEventAdminTest {
 
     private static class DummyEventHandler implements EventHandler {
 
-        private final List<Event> receivedEvents = new ArrayList<Event>();
+        private final List<Event> receivedEvents = new CopyOnWriteArrayList<>();
 
         @Override
         public void handleEvent(Event event) {

--- a/core/src/test/resources/simplelogger.properties
+++ b/core/src/test/resources/simplelogger.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-org.slf4j.simpleLogger.defaultLogLevel=error
+org.slf4j.simpleLogger.defaultLogLevel=debug


### PR DESCRIPTION
Make DummyEventHandler thread-safe. The EventHandler is potentially invoked from multiple threads, and improper synchronisation can lead to missing events.