### PR TITLE
SLING-12157 [osgi-mock] late binding does not work for non-service DS components

### DIFF
--- a/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilBindUnbindTest.java
+++ b/core/src/test/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtilBindUnbindTest.java
@@ -141,8 +141,7 @@ public class OsgiServiceUtilBindUnbindTest {
 
     @SuppressWarnings({ "null", "unchecked" })
     private <T> T registerInjectService(T service) {
-        MockOsgi.injectServices(service, bundleContext);
-        bundleContext.registerService((Class<T>)service.getClass(), service, (Dictionary)null);
+        MockOsgi.registerInjectActivateService(service, bundleContext);
         return service;
     }
 


### PR DESCRIPTION
- OsgiServiceUtilBindUnbindTest seems to have worked around this issue, hence the change
- factored out "registerDSComponent" in order to reduce code duplication
- with this fix, a non-service DS component is stored in MockBundleContext#registeredServices but its MockServiceRegistration#clazzes field is an empty set and thus cannot be retrieved via BundleContext#getServiceReference