### PR TITLE
SLING-12413: Keep sorting consistent in collection references whenever services are registered

### DIFF
--- a/core/src/main/java/org/apache/sling/testing/mock/osgi/MockBundleContext.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/osgi/MockBundleContext.java
@@ -194,7 +194,8 @@ class MockBundleContext implements BundleContext {
                         OsgiServiceUtil.invokeBindMethod(
                                 reference,
                                 referenceInfo.getServiceRegistration().getService(),
-                                new ServiceInfo(registration));
+                                new ServiceInfo(registration),
+                                this);
                         break;
                     default:
                         throw new RuntimeException("Unepxected cardinality: " + reference.getCardinality());
@@ -289,7 +290,8 @@ class MockBundleContext implements BundleContext {
                         OsgiServiceUtil.invokeUnbindMethod(
                                 reference,
                                 referenceInfo.getServiceRegistration().getService(),
-                                new ServiceInfo(registration));
+                                new ServiceInfo(registration),
+                                this);
                         break;
                     default:
                         throw new RuntimeException("Unepxected cardinality: " + reference.getCardinality());

--- a/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtil.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiServiceUtil.java
@@ -845,15 +845,22 @@ final class OsgiServiceUtil {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static void bindCollectionReference(
             Reference reference, BundleContext bundleContext, Object target, Field field) {
         try {
             field.setAccessible(true);
+            Collection<Object> collection = (Collection<Object>) field.get(target);
+            if (collection == null) {
+                collection = newCollectionInstance(field.getType());
+            } else {
+                collection.clear();
+            }
+
             List<ServiceInfo<?>> matchingServices =
                     getMatchingServices(reference.getInterfaceTypeAsClass(), bundleContext, reference.getTarget());
             matchingServices.sort(Comparator.comparing(ServiceInfo::getServiceReference));
 
-            Collection<Object> collection = newCollectionInstance(field.getType());
             if (FieldCollectionType.REFERENCE.equals(reference.getFieldCollectionType())) {
                 matchingServices.stream().map(ServiceInfo::getServiceReference).forEach(collection::add);
             } else if (FieldCollectionType.SERVICE.equals(reference.getFieldCollectionType())) {

--- a/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/Service6VolatileMultipleReferences.java
+++ b/test-services/src/main/java/org/apache/sling/testing/mock/osgi/testsvc/osgiserviceutil/Service6VolatileMultipleReferences.java
@@ -36,4 +36,8 @@ public class Service6VolatileMultipleReferences {
         }
         return builder.toString();
     }
+
+    public List<RankedService> getRankedServices() {
+        return this.rankedServices;
+    }
 }


### PR DESCRIPTION
I changed it so a collection reference is always constructed from scratch (new instance the first time, cleared entirely afterwards)... seems to work.  
All tests succeed and my example test demonstrating the inconsistent sorting (https://github.com/senn/aemcontext-no-serviceranking-ordering/blob/incorrect-ordering-depending-on-injection-time/src/test/java/com/github/senn/services/InjectionTimeOrderingTest.java) also succeeds if i build this locally and change the osgi-mock version to 3.5.1-SNAPSHOT in that project.

I'm no expert in OSGi bundlecontext / service registration so it needs a good thinking through and review.

What do you think?  