### PR TITLE
SLING-12528 Fix "XML parsers should not be vulnerable to XXE attacks"

### DIFF
--- a/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiMetadataUtil.java
+++ b/core/src/main/java/org/apache/sling/testing/mock/osgi/OsgiMetadataUtil.java
@@ -76,6 +76,11 @@ final class OsgiMetadataUtil {
 
     static {
         DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException ex) {
+            throw new IllegalStateException("Error setting FEATURE_SECURE_PROCESSING.", ex);
+        }
         DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
     }
 
@@ -220,9 +225,7 @@ final class OsgiMetadataUtil {
 
     private static Document toXmlDocument(InputStream inputStream, String path) {
         try {
-            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-            documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            DocumentBuilder documentBuilder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
             return documentBuilder.parse(inputStream);
         } catch (ParserConfigurationException ex) {
             throw new RuntimeException("Unable to read classpath resource: " + path, ex);


### PR DESCRIPTION
there was another instances of DocumentBuilderFactory - reuse it